### PR TITLE
Crash report obfuscated

### DIFF
--- a/PaymentLibrary-Android/.idea/caches/deviceStreaming.xml
+++ b/PaymentLibrary-Android/.idea/caches/deviceStreaming.xml
@@ -103,6 +103,18 @@
         <PersistentDeviceSelectionData>
           <option name="api" value="35" />
           <option name="brand" value="samsung" />
+          <option name="codename" value="a05s" />
+          <option name="id" value="a05s" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A05s" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
           <option name="codename" value="a06" />
           <option name="id" value="a06" />
           <option name="labId" value="google" />
@@ -173,7 +185,43 @@
           <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a26x" />
+          <option name="id" value="a26x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A266B" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a34x" />
+          <option name="id" value="a34x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A346N" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a35x" />
+          <option name="id" value="a35x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="A35" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a35x" />
           <option name="id" value="a35x" />
@@ -192,6 +240,30 @@
           <option name="labId" value="google" />
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-A366E" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a36xq" />
+          <option name="id" value="a36xq" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A366E" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a56x" />
+          <option name="id" value="a56x" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="SM-A566E" />
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
@@ -416,7 +488,32 @@
           <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e1q" />
+          <option name="default" value="true" />
+          <option name="id" value="e1q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e3q" />
+          <option name="id" value="e3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24 Ultra" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
           <option name="brand" value="samsung" />
           <option name="codename" value="e3q" />
           <option name="id" value="e3q" />
@@ -670,6 +767,18 @@
           <option name="screenY" value="2244" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="35" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="lamul" />
+          <option name="id" value="lamul" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="moto g05" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1604" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="motorola" />
           <option name="codename" value="lion" />
@@ -766,7 +875,31 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="pa2q" />
+          <option name="id" value="pa2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S25+" />
+          <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="35" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="pa3q" />
+          <option name="id" value="pa3q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S25 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3120" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
           <option name="brand" value="samsung" />
           <option name="codename" value="pa3q" />
           <option name="id" value="pa3q" />
@@ -848,6 +981,18 @@
           <option name="manufacturer" value="Samsung" />
           <option name="name" value="SM-S711U" />
           <option name="screenDensity" value="450" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="36" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="r9q" />
+          <option name="id" value="r9q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S21 FE 5G" />
+          <option name="screenDensity" value="480" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2340" />
         </PersistentDeviceSelectionData>
@@ -974,6 +1119,18 @@
           <option name="screenDensity" value="450" />
           <option name="screenX" value="1080" />
           <option name="screenY" value="2408" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="y2q" />
+          <option name="id" value="y2q" />
+          <option name="labId" value="google" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="S20 Plus 5G" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3200" />
         </PersistentDeviceSelectionData>
       </list>
     </option>

--- a/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/BusinessEventsClient.kt
+++ b/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/BusinessEventsClient.kt
@@ -301,6 +301,7 @@ object BusinessEventsClient {
         val now = Date()
         val data = mutableMapOf<String, JsonElement>()
         data["action.id"] = JsonPrimitive(UUID.randomUUID().toString())
+        data["action.starttime"] = JsonPrimitive(now.time)
         parentActionId?.let { data["action.parentId"] = JsonPrimitive(it.toString()) }
         sessionId?.let { data["session.id"] = JsonPrimitive(it) }
         error?.let { data["action.error"] = JsonPrimitive(it) }

--- a/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/BusinessEventsClient.kt
+++ b/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/BusinessEventsClient.kt
@@ -24,6 +24,11 @@ import com.dynatracese.paymentlibrary.Secrets
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -45,6 +50,12 @@ import kotlin.coroutines.cancellation.CancellationException
 
 // MARK: - Public API
 
+// Coroutine context key for tracking current action ID
+private data class CurrentActionKey(val actionId: UUID) : CoroutineContext.Element {
+    companion object Key : CoroutineContext.Key<CurrentActionKey>
+    override val key: CoroutineContext.Key<*> get() = Key
+}
+
 object BusinessEventsClient {
 
     sealed class Auth {
@@ -65,7 +76,8 @@ object BusinessEventsClient {
         val appVersion: String? = null,         // optional meta
         val deviceInfo: String? = null,         // optional meta
         val deviceMetadata: DeviceMetadataCollector.DeviceMetadata? = null, // comprehensive device metadata
-        val maxRetryAttempts: Int = 3           // configurable retry count
+        val maxRetryAttempts: Int = 3,          // configurable retry count
+        val actionTimeoutSeconds: Long = 7      // timeout in seconds before auto-finishing actions
     )
 
     data class BeginOptions(
@@ -174,9 +186,31 @@ object BusinessEventsClient {
             startedAt = now,
             attributes = opts.attributes.toJsonElementMap(),
             parentActionId = effectiveParentId,
-            eventType = "custom.rum.sdk.action" // Always use fixed event type
+            eventType = "custom.rum.sdk.action", // Always use fixed event type
+            timeoutJob = null
         )
+        
+        // Schedule timeout job
+        val timeoutJob = GlobalScope.launch {
+            delay(cfg.actionTimeoutSeconds * 1000)
+            try {
+                endAction(
+                    ctx.id,
+                    status = "TIMEOUT",
+                    error = "Action exceeded timeout of ${cfg.actionTimeoutSeconds}s"
+                )
+                Log.i("BusinessEventsClient", "Action '${ctx.name}' auto-finished with TIMEOUT status")
+            } catch (e: ClientError.UnknownAction) {
+                // Action was already finished by user code - this is expected and not an error
+                Log.d("BusinessEventsClient", "Action '${ctx.name}' was already finished when timeout fired")
+            } catch (e: Exception) {
+                Log.e("BusinessEventsClient", "Failed to auto-finish timed out action '${ctx.name}': ${e.message}")
+            }
+        }
+        ctx.timeoutJob = timeoutJob
+        
         store.insert(ctx)
+        Log.d("BusinessEventsClient", "Action '${ctx.name}' started, timeout: ${cfg.actionTimeoutSeconds}s")
         return ctx.id
     }
 
@@ -189,6 +223,10 @@ object BusinessEventsClient {
     ) {
         val cfg = config ?: throw ClientError.NotConfigured
         val ctx = store.remove(actionId) ?: throw ClientError.UnknownAction
+        
+        // Cancel timeout job since action is ending normally
+        ctx.timeoutJob?.cancel()
+        ctx.timeoutJob = null
 
         val finishedAt = Date()
         val durationMs = (finishedAt.time - ctx.startedAt.time)
@@ -252,28 +290,44 @@ object BusinessEventsClient {
         Log.d("BusinessEventsClient", "Executo end action")
     }
 
-    // Convenience wrapper that auto-finalizes
+    // Convenience wrapper that auto-finalizes with automatic parent-child relationship tracking
     suspend fun <T> withAction(
         name: String,
         attributes: Map<String, Any> = emptyMap(),
         parentActionId: UUID? = null,
         body: suspend () -> T
     ): T {
-        val id = beginAction(BeginOptions(name, attributes, parentActionId))
-        try {
-            val result = body()
-            endAction(id, status = "SUCCESS")
-            Log.d("BusinessEventsClient", "Action name: $name")
-            return result
-        } catch (e: Exception) {
-            // Avoid re-throwing cancellation exceptions, let them propagate
-            if (e is CancellationException) throw e
+        // Automatically use current action as parent if no explicit parent provided
+        val currentActionId = coroutineContext[CurrentActionKey]?.actionId
+        val effectiveParentId = parentActionId ?: currentActionId
+        
+        val id = beginAction(BeginOptions(name, attributes, effectiveParentId))
+        
+        // Set this action as current in coroutine context for nested actions
+        return withContext(CurrentActionKey(id)) {
             try {
-                endAction(id, status = "FAILURE", error = e.message ?: e.toString())
-            } catch (endActionError: Exception) {
-                Log.e("BusinessEventsClient", "Failed to send error event: $endActionError")
+                val result = body()
+                try {
+                    endAction(id, status = "SUCCESS")
+                    Log.d("BusinessEventsClient", "Action name: $name")
+                } catch (e: ClientError.UnknownAction) {
+                    // Action was already finished by timeout - this is expected
+                    Log.d("BusinessEventsClient", "Action '$name' was already finished (likely by timeout)")
+                }
+                result
+            } catch (e: Exception) {
+                // Avoid re-throwing cancellation exceptions, let them propagate
+                if (e is CancellationException) throw e
+                try {
+                    endAction(id, status = "FAILURE", error = e.message ?: e.toString())
+                } catch (endActionError: ClientError.UnknownAction) {
+                    // Action was already finished by timeout - this is expected
+                    Log.d("BusinessEventsClient", "Action '$name' was already finished when trying to record failure (likely by timeout)")
+                } catch (endActionError: Exception) {
+                    Log.e("BusinessEventsClient", "Failed to send error event: $endActionError")
+                }
+                throw e
             }
-            throw e
         }
     }
 
@@ -346,7 +400,8 @@ object BusinessEventsClient {
         val startedAt: Date,
         val attributes: Map<String, JsonElement>,
         val parentActionId: UUID?,
-        val eventType: String
+        val eventType: String,
+        var timeoutJob: kotlinx.coroutines.Job? = null
     )
 
     sealed class ClientError : Exception() {
@@ -427,7 +482,11 @@ private class InMemoryStore {
     private val dict = ConcurrentHashMap<UUID, BusinessEventsClient.ActionContext>()
     fun insert(ctx: BusinessEventsClient.ActionContext) { dict[ctx.id] = ctx }
     fun lookup(id: UUID): BusinessEventsClient.ActionContext? = dict[id]
-    fun remove(id: UUID): BusinessEventsClient.ActionContext? = dict.remove(id)
+    fun remove(id: UUID): BusinessEventsClient.ActionContext? {
+        val ctx = dict.remove(id)
+        ctx?.timeoutJob?.cancel()
+        return ctx
+    }
     fun getLastActionContext(): BusinessEventsClient.ActionContext? = dict.values.lastOrNull()
 }
 

--- a/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/PaymentCrashHandler.kt
+++ b/PaymentLibrary-Android/PaymentLibrary/src/main/java/com/dynatracese/paymentlibrary/PaymentCrashHandler.kt
@@ -9,10 +9,15 @@ import java.io.StringWriter
 import java.util.*
 import kotlin.system.exitProcess
 import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
 class PaymentCrashHandler(private val context: Context, private val originalHandler: Thread.UncaughtExceptionHandler?) : Thread.UncaughtExceptionHandler {
 
     companion object {
         private var instance: PaymentCrashHandler? = null
+        
+        // Flag to prevent duplicate crash reports
+        @Volatile
+        private var crashReported = false
 
         fun register(context: Context) {
             val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
@@ -20,26 +25,121 @@ class PaymentCrashHandler(private val context: Context, private val originalHand
                 instance = PaymentCrashHandler(context, originalHandler)
                 Thread.setDefaultUncaughtExceptionHandler(instance)
                 Log.i("registered status", "register: registered successfully")
+                
+                // Send any saved crash reports from previous crashes
+                sendSavedCrashReports(context)
+            }
+        }
+        
+        private fun sendSavedCrashReports(context: Context) {
+            val crashFile = File(context.filesDir, "crash_report.json")
+            if (!crashFile.exists()) return
+            
+            Log.i("PaymentCrashHandler", "📤 Found saved crash report, sending...")
+            
+            try {
+                val crashJson = crashFile.readText()
+                val crashData = JSONObject(crashJson)
+                
+                val extraAttributes = mutableMapOf<String, Any>(
+                    "saved_report" to true,
+                    "device" to android.os.Build.MODEL
+                )
+                
+                if (crashData.has("crash.class")) {
+                    extraAttributes["crash.class"] = crashData.getString("crash.class")
+                }
+                if (crashData.has("crash.stackTrace")) {
+                    extraAttributes["crash.stackTrace"] = crashData.getString("crash.stackTrace")
+                }
+                
+                val errorMessage = if (crashData.has("action.error")) crashData.getString("action.error") else null
+                val parentActionId = if (crashData.has("parentActionId") && !crashData.isNull("parentActionId")) {
+                    UUID.fromString(crashData.getString("parentActionId"))
+                } else null
+                val sessionId = if (crashData.has("sessionId")) crashData.getString("sessionId") else BusinessEventsClient.sessionId
+                
+                runBlocking {
+                    try {
+                        BusinessEventsClient.sendCrashReport(
+                            parentActionId = parentActionId,
+                            sessionId = sessionId,
+                            error = errorMessage,
+                            extraAttributes = extraAttributes
+                        )
+                        // Delete file after successful send
+                        crashFile.delete()
+                        Log.i("PaymentCrashHandler", "✅ Saved crash report sent and deleted")
+                    } catch (e: Exception) {
+                        Log.e("PaymentCrashHandler", "❌ Failed to send saved crash report: ${e.message}")
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("PaymentCrashHandler", "Failed to parse saved crash report: ${e.message}")
             }
         }
 
-        fun reportCrash(throwable: Throwable) {
+        fun reportCrash(context: Context, throwable: Throwable) {
+            // Prevent duplicate crash reports
+            if (crashReported) {
+                Log.w("PaymentCrashHandler", "⚠️ CRASH ALREADY REPORTED - Skipping duplicate")
+                return
+            }
+            crashReported = true
+            
             val sw = StringWriter()
             val pw = PrintWriter(sw)
             throwable.printStackTrace(pw)
             val stackTrace = sw.toString()
             val description = throwable.message
+            
+            // Get current action context
+            val actionContext = BusinessEventsClient.getCurrentActionContext()
+            val sessionId = BusinessEventsClient.sessionId
+            
+            // Save crash data as JSON FIRST
+            val crashData = JSONObject().apply {
+                put("crash.class", throwable.javaClass.simpleName)
+                put("crash.stackTrace", stackTrace)
+                put("action.error", description ?: "unknown")
+                put("parentActionId", actionContext?.id?.toString())
+                put("sessionId", sessionId)
+            }
+            
+            val crashFile = File(context.filesDir, "crash_report.json")
+            try {
+                crashFile.writeText(crashData.toString())
+                Log.i("PaymentCrashHandler", "💾 Crash data saved to disk")
+            } catch (e: Exception) {
+                Log.e("PaymentCrashHandler", "Failed to save crash data: ${e.message}")
+            }
+            
+            var crashSentSuccessfully = false
+            
+            // If there's an open action, finish it with CRASH status first
+            actionContext?.let { ctx ->
+                try {
+                    runBlocking {
+                        BusinessEventsClient.endAction(
+                            actionId = ctx.id,
+                            status = "CRASH",
+                            error = description
+                        )
+                    }
+                    Log.i("PaymentCrashHandler", "✅ Open action finished with CRASH status")
+                } catch (e: Exception) {
+                    Log.e("PaymentCrashHandler", "❌ Failed to finish open action: ${e.message}")
+                }
+            }
+            
+            // Now send the crash report
+            val parentActionId = actionContext?.id
             val extraAttributes = mapOf(
                 "crash.class" to throwable.javaClass.simpleName,
                 "crash.stackTrace" to stackTrace,
                 "device" to android.os.Build.MODEL
             )
-            // Get current action context for parentActionId and sessionId
-            val actionContext = BusinessEventsClient.getCurrentActionContext()
-            val parentActionId = actionContext?.parentActionId
-            val sessionId = BusinessEventsClient.sessionId
             
-            // Use runBlocking to ensure crash report is sent before app terminates
             try {
                 runBlocking {
                     BusinessEventsClient.sendCrashReport(
@@ -49,45 +149,113 @@ class PaymentCrashHandler(private val context: Context, private val originalHand
                         extraAttributes = extraAttributes
                     )
                 }
-                Log.i("PaymentCrashHandler", "Crash report sent successfully")
+                Log.i("PaymentCrashHandler", "✅ Crash report sent successfully")
+                crashSentSuccessfully = true
             } catch (e: Exception) {
-                Log.e("PaymentCrashHandler", "Failed to send crash report: ${e.message}", e)
+                Log.e("PaymentCrashHandler", "❌ Failed to send crash report: ${e.message}", e)
+            }
+            
+            // Delete saved report only if we successfully sent it
+            if (crashSentSuccessfully) {
+                crashFile.delete()
+                Log.i("PaymentCrashHandler", "✅ Saved crash report deleted after successful send")
+            } else {
+                Log.w("PaymentCrashHandler", "⚠️ Crash report saved to disk for next reboot")
             }
         }
     }
 
     override fun uncaughtException(thread: Thread, throwable: Throwable) {
-        Log.i("PaymentCrashHandler", "Uncaught exception occurred: ${throwable.javaClass.simpleName}")
+        // Prevent duplicate crash reports
+        if (crashReported) {
+            Log.w("PaymentCrashHandler", "⚠️ CRASH ALREADY REPORTED - Skipping duplicate")
+            return
+        }
+        crashReported = true
         
-        // 1. Send crash report to Dynatrace (blocking operation)
-        reportCrash(throwable)
+        Log.i("PaymentCrashHandler", "🔴 CRASH HANDLER CALLED - Exception: ${throwable.javaClass.simpleName}")
         
-        // 2. Collect and serialize crash data for file storage
         val sw = StringWriter()
         val pw = PrintWriter(sw)
         throwable.printStackTrace(pw)
         val stackTrace = sw.toString()
         val description = throwable.message
         
-        val crashInfo = "Timestamp: ${Date()}\n" +
-                "Device: ${android.os.Build.MODEL}\n" +
-                "Exception Class: ${throwable.javaClass.simpleName}\n" +
-                "Description: $description\n" +
-                "Stack Trace:\n$stackTrace"
-
-        // 3. Write to a file
+        Log.i("PaymentCrashHandler", "🔴 StackTrace:\n$stackTrace")
+        
+        // Get current action context
+        val actionContext = BusinessEventsClient.getCurrentActionContext()
+        val sessionId = BusinessEventsClient.sessionId
+        
+        // Save crash data as JSON FIRST (before attempting to send)
+        val crashData = JSONObject().apply {
+            put("crash.class", throwable.javaClass.simpleName)
+            put("crash.stackTrace", stackTrace)
+            put("action.error", description ?: "unknown")
+            put("parentActionId", actionContext?.id?.toString())
+            put("sessionId", sessionId)
+        }
+        
+        val crashFile = File(context.filesDir, "crash_report.json")
         try {
-            val filename = "payment_crash_report_${System.currentTimeMillis()}.log"
-            val file = File(context.filesDir, filename)
-            FileOutputStream(file).use {
-                it.write(crashInfo.toByteArray())
-            }
-            Log.d("PaymentCrashHandler", "Crash report saved to ${file.absolutePath}")
+            crashFile.writeText(crashData.toString())
+            Log.i("PaymentCrashHandler", "💾 Crash data saved to disk")
         } catch (e: Exception) {
-            Log.e("PaymentCrashHandler", "Failed to save crash report", e)
+            Log.e("PaymentCrashHandler", "Failed to save crash data: ${e.message}")
+        }
+        
+        var crashSentSuccessfully = false
+        
+        // If there's an open action, finish it with CRASH status first
+        actionContext?.let { ctx ->
+            try {
+                Log.i("PaymentCrashHandler", "🔴 Finishing open action '${ctx.name}' with CRASH status...")
+                runBlocking {
+                    BusinessEventsClient.endAction(
+                        actionId = ctx.id,
+                        status = "CRASH",
+                        error = description
+                    )
+                }
+                Log.i("PaymentCrashHandler", "✅ Open action finished with CRASH status")
+            } catch (e: Exception) {
+                Log.e("PaymentCrashHandler", "❌ Failed to finish open action: ${e.message}")
+            }
+        }
+        
+        // Now send the crash report
+        val parentActionId = actionContext?.id
+        val extraAttributes = mapOf(
+            "crash.class" to throwable.javaClass.simpleName,
+            "crash.stackTrace" to stackTrace,
+            "device" to android.os.Build.MODEL
+        )
+        
+        try {
+            Log.i("PaymentCrashHandler", "🔴 Sending crash report...")
+            runBlocking {
+                BusinessEventsClient.sendCrashReport(
+                    parentActionId = parentActionId,
+                    sessionId = sessionId,
+                    error = description,
+                    extraAttributes = extraAttributes
+                )
+            }
+            Log.i("PaymentCrashHandler", "✅ Crash report sent successfully")
+            crashSentSuccessfully = true
+        } catch (e: Exception) {
+            Log.e("PaymentCrashHandler", "❌ Failed to send crash report: ${e.message}")
+        }
+        
+        // Delete saved report only if we successfully sent it
+        if (crashSentSuccessfully) {
+            crashFile.delete()
+            Log.i("PaymentCrashHandler", "✅ Saved crash report deleted after successful send")
+        } else {
+            Log.w("PaymentCrashHandler", "⚠️ Crash report saved to disk for next reboot")
         }
 
-        // 4. Call the original handler to ensure other crash reporters work
+        // Call the original handler to ensure other crash reporters work
         originalHandler?.uncaughtException(thread, throwable)
             ?: exitProcess(1)
     }

--- a/PaymentLibrary-iOS/PaymentLibrary/CrashReporterKit.swift
+++ b/PaymentLibrary-iOS/PaymentLibrary/CrashReporterKit.swift
@@ -15,6 +15,9 @@ final class CrashReporterKit {
     static let shared = CrashReporterKit()
     private let crashLogFile = "crash_log.txt"
     
+    // Flag to prevent duplicate crash reports (exception handler + signal handler both firing)
+    private static var crashReported = false
+    
     // Helper to get device model
     private static var deviceModel: String {
         #if canImport(UIKit)
@@ -33,15 +36,30 @@ final class CrashReporterKit {
             CrashReporterKit.shared.handle(exception: exception)
         }
         setupSignalHandler()
+        // Send any saved crash reports from previous crashes that failed to send
         sendCrashReportIfExists()
     }
 
     // MARK: - Exception Handling
 
     private func handle(exception: NSException) {
+        // Prevent duplicate crash reports
+        guard !Self.crashReported else {
+            print("⚠️ CRASH ALREADY REPORTED - Skipping duplicate exception handler")
+            return
+        }
+        Self.crashReported = true
+        
+        // Log IMMEDIATELY to confirm handler is called
+        os_log("🔴 CRASH HANDLER CALLED - Exception: %@", log: OSLog.default, type: .fault, exception.name.rawValue)
+        print("🔴 CRASH HANDLER CALLED - Exception: \(exception.name.rawValue)")
+        
         let stackTrace = exception.callStackSymbols.joined(separator: "\n")
         let errorMessage = exception.reason ?? "unknown"
         
+        os_log("🔴 CRASH HANDLER CALLED - StackTrace: %@", log: OSLog.default, type: .fault, stackTrace)
+        print("🔴 CRASH HANDLER CALLED - StackTrace: \(stackTrace)")
+
         let extraAttributes: [String: AnyEncodable] = [
             "crash.class": AnyEncodable(exception.name.rawValue),
             "crash.stackTrace": AnyEncodable(stackTrace),
@@ -50,81 +68,150 @@ final class CrashReporterKit {
         
         // Get current action context for parentActionId and sessionId
         let actionContext = BusinessEventsClient.shared.getCurrentActionContext()
-        let parentActionId = actionContext?.parentActionId
         let sessionId = BusinessEventsClient.shared.sessionId
         
-        // Send crash report synchronously using a semaphore to block until complete
-        let semaphore = DispatchSemaphore(value: 0)
-        
-        Task {
+        // If there's an open action, finish it with CRASH status first
+        if let currentAction = actionContext {
             do {
-                try await BusinessEventsClient.shared.sendCrashReport(
-                    parentActionId: parentActionId,
-                    sessionId: sessionId,
-                    error: errorMessage,
-                    extraAttributes: extraAttributes
+                print("🔴 Finishing open action '\(currentAction.name)' with CRASH status...")
+                try BusinessEventsClient.shared.endActionSync(
+                    currentAction.id,
+                    status: "CRASH",
+                    error: errorMessage
                 )
-                os_log("Crash report sent successfully", log: OSLog.default, type: .info)
+                print("✅ Open action finished with CRASH status")
             } catch {
-                os_log("Failed to send crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+                print("❌ Failed to finish open action: \(error)")
             }
-            semaphore.signal()
         }
         
-        // Block until the crash report is sent (with timeout)
-        _ = semaphore.wait(timeout: .now() + 5.0)
+        // Now send the crash report (parent will be the action we just finished)
+        let parentActionId = actionContext?.id
         
-        // Write to file for backup
-        let report = """
-        [EXCEPTION]
-        Name: \(exception.name)
-        Reason: \(errorMessage)
-        Stack Trace:
-        \(stackTrace)
-        """
-        writeReport(report)
+        // Write to file for backup FIRST (before attempting send)
+        // Save as structured data so we can send identical event on next reboot
+        let crashData: [String: Any] = [
+            "crash.class": exception.name.rawValue,
+            "crash.stackTrace": stackTrace,
+            "action.error": errorMessage,
+            "parentActionId": parentActionId?.uuidString as Any,
+            "sessionId": sessionId as Any
+        ]
+        writeCrashData(crashData)
+        
+        // Send crash report synchronously - blocks until complete or times out
+        var crashSentSuccessfully = false
+        do {
+            os_log("🔴 Starting to send crash report synchronously...", log: OSLog.default, type: .fault)
+            print("🔴 Sending crash report for session: \(sessionId ?? "none")")
+            
+            try BusinessEventsClient.shared.sendCrashReportSync(
+                parentActionId: parentActionId,
+                sessionId: sessionId,
+                error: errorMessage,
+                extraAttributes: extraAttributes
+            )
+            os_log("✅ Crash report sent successfully", log: OSLog.default, type: .info)
+            print("✅ Crash report sent successfully")
+            crashSentSuccessfully = true
+        } catch {
+            os_log("❌ Failed to send crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+            print("❌ Failed to send crash report: \(error)")
+        }
+        
+        // Delete saved report only if we successfully sent it
+        if crashSentSuccessfully {
+            deleteSavedReport()
+            print("✅ Saved crash report deleted after successful send")
+        } else {
+            print("⚠️ Crash report saved to disk for next reboot")
+        }
     }
 
     // MARK: - Signal Handling
 
     private func setupSignalHandler() {
         func handleSignal(_ signal: Int32) {
+            // Prevent duplicate crash reports (NSException already handled this crash)
+            guard !CrashReporterKit.crashReported else {
+                print("⚠️ CRASH ALREADY REPORTED - Skipping duplicate signal handler")
+                exit(signal)
+            }
+            CrashReporterKit.crashReported = true
+            
             let errorMessage = "App crashed with signal: \(signal)"
+            
+            // Capture stack trace at crash time
+            let stackTrace = Thread.callStackSymbols.joined(separator: "\n")
+            
+            os_log("🔴 SIGNAL CRASH - Signal: %d, StackTrace: %@", log: OSLog.default, type: .fault, signal, stackTrace)
+            print("🔴 SIGNAL CRASH - Signal: \(signal)")
+            print("🔴 StackTrace:\n\(stackTrace)")
             
             let extraAttributes: [String: AnyEncodable] = [
                 "crash.class": AnyEncodable("Signal"),
                 "crash.signal": AnyEncodable(signal),
+                "crash.stackTrace": AnyEncodable(stackTrace),
                 "device": AnyEncodable(CrashReporterKit.deviceModel)
             ]
             
             // Get current action context for parentActionId and sessionId
             let actionContext = BusinessEventsClient.shared.getCurrentActionContext()
-            let parentActionId = actionContext?.parentActionId
             let sessionId = BusinessEventsClient.shared.sessionId
             
-            // Send crash report synchronously
-            let semaphore = DispatchSemaphore(value: 0)
-            
-            Task {
+            // If there's an open action, finish it with CRASH status first
+            if let currentAction = actionContext {
                 do {
-                    try await BusinessEventsClient.shared.sendCrashReport(
-                        parentActionId: parentActionId,
-                        sessionId: sessionId,
-                        error: errorMessage,
-                        extraAttributes: extraAttributes
+                    print("🔴 Finishing open action '\(currentAction.name)' with CRASH status...")
+                    try BusinessEventsClient.shared.endActionSync(
+                        currentAction.id,
+                        status: "CRASH",
+                        error: errorMessage
                     )
-                    os_log("Signal crash report sent successfully", log: OSLog.default, type: .info)
+                    print("✅ Open action finished with CRASH status")
                 } catch {
-                    os_log("Failed to send signal crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+                    print("❌ Failed to finish open action: \(error)")
                 }
-                semaphore.signal()
             }
             
-            // Block until the crash report is sent (with timeout)
-            _ = semaphore.wait(timeout: .now() + 5.0)
+            // Now send the crash report (parent will be the action we just finished)
+            let parentActionId = actionContext?.id
             
-            let report = "[SIGNAL] \(errorMessage)"
-            CrashReporterKit.shared.writeReport(report)
+            // Write to file for backup FIRST
+            // Save as structured data so we can send identical event on next reboot
+            let crashData: [String: Any] = [
+                "crash.class": "Signal",
+                "crash.signal": signal,
+                "crash.stackTrace": stackTrace,
+                "action.error": errorMessage,
+                "parentActionId": parentActionId?.uuidString as Any,
+                "sessionId": sessionId as Any
+            ]
+            CrashReporterKit.shared.writeCrashData(crashData)
+            
+            // Send crash report synchronously - blocks until complete or times out
+            var crashSentSuccessfully = false
+            do {
+                try BusinessEventsClient.shared.sendCrashReportSync(
+                    parentActionId: parentActionId,
+                    sessionId: sessionId,
+                    error: errorMessage,
+                    extraAttributes: extraAttributes
+                )
+                os_log("Signal crash report sent successfully", log: OSLog.default, type: .info)
+                crashSentSuccessfully = true
+            } catch {
+                os_log("Failed to send signal crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+            }
+            
+            // Delete saved report only if we successfully sent it
+            if crashSentSuccessfully {
+                CrashReporterKit.shared.deleteSavedReport()
+                print("✅ Saved crash report deleted after successful send")
+            } else {
+                print("⚠️ Crash report saved to disk for next reboot")
+            }
+            
             exit(signal)
         }
 
@@ -150,36 +237,53 @@ final class CrashReporterKit {
         
         // Get current action context for parentActionId and sessionId
         let actionContext = BusinessEventsClient.shared.getCurrentActionContext()
-        let parentActionId = actionContext?.parentActionId
         let sessionId = BusinessEventsClient.shared.sessionId
         
-        // Send crash report synchronously
-        let semaphore = DispatchSemaphore(value: 0)
-        
-        Task {
+        // If there's an open action, finish it with CRASH status first
+        if let currentAction = actionContext {
             do {
-                try await BusinessEventsClient.shared.sendCrashReport(
-                    parentActionId: parentActionId,
-                    sessionId: sessionId,
-                    error: errorMessage,
-                    extraAttributes: extraAttributes
+                print("🔴 Finishing open action '\(currentAction.name)' with CRASH status...")
+                try BusinessEventsClient.shared.endActionSync(
+                    currentAction.id,
+                    status: "CRASH",
+                    error: errorMessage
                 )
-                os_log("Manual crash report sent successfully", log: OSLog.default, type: .info)
+                print("✅ Open action finished with CRASH status")
             } catch {
-                os_log("Failed to send manual crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+                print("❌ Failed to finish open action: \(error)")
             }
-            semaphore.signal()
         }
         
-        // Block until the crash report is sent (with timeout)
-        _ = semaphore.wait(timeout: .now() + 5.0)
+        // Now send the crash report (parent will be the action we just finished)
+        let parentActionId = actionContext?.id
+        
+        // Send crash report synchronously - blocks until complete or times out
+        do {
+            try BusinessEventsClient.shared.sendCrashReportSync(
+                parentActionId: parentActionId,
+                sessionId: sessionId,
+                error: errorMessage,
+                extraAttributes: extraAttributes
+            )
+            os_log("Manual crash report sent successfully", log: OSLog.default, type: .info)
+        } catch {
+            os_log("Failed to send manual crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+        }
     }
 
     // MARK: - Save Report
 
-    private func writeReport(_ report: String) {
+    private func writeCrashData(_ crashData: [String: Any]) {
         let url = crashLogURL()
-        try? report.write(to: url, atomically: true, encoding: .utf8)
+        if let jsonData = try? JSONSerialization.data(withJSONObject: crashData, options: .prettyPrinted) {
+            try? jsonData.write(to: url, options: .atomic)
+            print("💾 Crash data saved to disk")
+        }
+    }
+    
+    private func deleteSavedReport() {
+        let url = crashLogURL()
+        try? FileManager.default.removeItem(at: url)
     }
 
     private func crashLogURL() -> URL {
@@ -192,29 +296,51 @@ final class CrashReporterKit {
     private func sendCrashReportIfExists() {
         let url = crashLogURL()
         guard FileManager.default.fileExists(atPath: url.path) else { return }
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return }
+        guard let jsonData = try? Data(contentsOf: url),
+              let crashData = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            print("⚠️ Failed to parse saved crash report")
+            return
+        }
 
+        print("📤 Sending saved crash report from previous session...")
+        
         Task {
             do {
-                let crashAttributes: [String: AnyEncodable] = [
-                    "crash.details": AnyEncodable(content),
-                    "crash.type": AnyEncodable("saved_report")
+                // Reconstruct the crash attributes from saved data
+                var crashAttributes: [String: AnyEncodable] = [
+                    "saved_report": AnyEncodable(true),
+                    "device": AnyEncodable(Self.deviceModel)
                 ]
                 
-                let sessionId = BusinessEventsClient.shared.sessionId
+                if let crashClass = crashData["crash.class"] as? String {
+                    crashAttributes["crash.class"] = AnyEncodable(crashClass)
+                }
+                if let stackTrace = crashData["crash.stackTrace"] as? String {
+                    crashAttributes["crash.stackTrace"] = AnyEncodable(stackTrace)
+                }
+                if let signal = crashData["crash.signal"] as? Int32 {
+                    crashAttributes["crash.signal"] = AnyEncodable(signal)
+                }
+                
+                let errorMessage = crashData["action.error"] as? String
+                let parentActionIdStr = crashData["parentActionId"] as? String
+                let parentActionId = parentActionIdStr.flatMap { UUID(uuidString: $0) }
+                let sessionId = crashData["sessionId"] as? String ?? BusinessEventsClient.shared.sessionId
                 
                 try await BusinessEventsClient.shared.sendCrashReport(
-                    parentActionId: nil,
+                    parentActionId: parentActionId,
                     sessionId: sessionId,
-                    error: "Saved crash report",
+                    error: errorMessage,
                     extraAttributes: crashAttributes
                 )
 
                 // Remove the report file after a successful send
                 try FileManager.default.removeItem(at: url)
-                os_log("Saved crash report sent and removed", log: OSLog.default, type: .info)
+                os_log("✅ Saved crash report sent and removed", log: OSLog.default, type: .info)
+                print("✅ Saved crash report sent and removed")
             } catch {
-                os_log("Failed to send saved crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+                os_log("❌ Failed to send saved crash report: %@", log: OSLog.default, type: .error, error.localizedDescription)
+                print("❌ Failed to send saved crash report: \(error)")
             }
         }
     }

--- a/PaymentLibrary-iOS/PaymentLibrary/PaymentClient.swift
+++ b/PaymentLibrary-iOS/PaymentLibrary/PaymentClient.swift
@@ -208,6 +208,17 @@ public final class PaymentClient {
 
             if crashStatus {
                 PaymentClient.logger.error("Simulating crash on purpose.")
+                
+                // Report the crash BEFORE it happens, then trigger NSException
+                // fatalError() doesn't reliably trigger crash handlers, so we use NSException instead
+                let exception = NSException(
+                    name: NSExceptionName("SimulatedCrash"),
+                    reason: "Simulated Payment Library Crash - Testing crash reporting",
+                    userInfo: ["crash.intentional": true]
+                )
+                exception.raise()
+                
+                // This won't be reached, but kept for safety
                 fatalError("Simulated Payment Library Crash")
             }
 


### PR DESCRIPTION
Action Timeout Mechanism

Added 7-second default timeout for all actions (configurable via actionTimeoutSeconds)
Actions exceeding timeout are automatically finished with status TIMEOUT
Timeout timers/jobs are properly canceled when actions finish normally
Implemented for both iOS (Timer) and Android (coroutine Job)
Crash Event Timestamps

Added action.starttime attribute to crash events (both platforms)
Uses milliseconds since epoch format for consistency with Dynatrace
Race Condition Fixes

Fixed crash when timeout fires while user code finishes the same action
withAction now catches UnknownAction gracefully instead of crashing
Timeout handler ignores UnknownAction when action was already finished
Both scenarios log debug messages instead of throwing errors
Parent-Child Action Tracking (Android)

Implemented coroutine context tracking for current action ID
Nested withAction calls now automatically inherit parent action ID
Matches iOS behavior using @TaskLocal equivalent for Android
Fixes missing action.parentId in nested action events
Cross-Platform Consistency

All features implemented identically on both iOS and Android
Both platforms successfully compile and build